### PR TITLE
 feat: Add Dependencies Tab with Package List View

### DIFF
--- a/src/api/packageApi.ts
+++ b/src/api/packageApi.ts
@@ -1,0 +1,25 @@
+import { Dependency } from './types';
+
+export const fetchPackageDependencies = async (packageId: string, version: string): Promise<Dependency[]> => {
+  // TODO: Replace with actual API call
+  return [
+    {
+      name: "proc-macro2",
+      version: "1.0.91",
+      description: "A substitute implementation of the compiler's `proc_macro` API to decouple token-based libraries from the procedural macro use case.",
+      features: ["NO DEFAULT FEATURES"]
+    },
+    {
+      name: "unicode-ident",
+      version: "1.0",
+      description: "Determine whether characters have the XID_Start or XID_Continue properties according to Unicode Standard Annex #31"
+    },
+    {
+      name: "quote",
+      version: "1.0.35",
+      description: "Quasi-quoting macro quote!(...)",
+      isOptional: true,
+      features: ["OPTIONAL", "NO DEFAULT FEATURES"]
+    }
+  ];
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,13 @@
+export interface Dependency {
+  name: string;
+  version: string;
+  description: string;
+  features?: string[];
+  isOptional?: boolean;
+}
+
+export interface PackageDetails {
+  id: string;
+  version: string;
+  dependencies: Dependency[];
+}

--- a/src/components/DependenciesList.tsx
+++ b/src/components/DependenciesList.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Box, Table, Text, Badge } from '@radix-ui/themes';
+import { Dependency } from '../api/types';
+import { fetchPackageDependencies } from '../api/packageApi';
+
+interface DependenciesListProps {
+  packageId: string;
+  version: string;
+}
+
+export const DependenciesList: React.FC<DependenciesListProps> = ({ packageId, version }) => {
+  const [dependencies, setDependencies] = useState<Dependency[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadDependencies = async () => {
+      try {
+        setLoading(true);
+        const deps = await fetchPackageDependencies(packageId, version);
+        setDependencies(deps);
+        setError(null);
+      } catch (err) {
+        setError('Failed to load dependencies');
+        console.error('Failed to load dependencies:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadDependencies();
+  }, [packageId, version]);
+
+  if (loading) {
+    return (
+      <Box p="4">
+        <Text size="2">Loading dependencies...</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box p="4">
+        <Text size="2" color="red">
+          {error}
+        </Text>
+      </Box>
+    );
+  }
+
+  if (dependencies.length === 0) {
+    return (
+      <Box p="4">
+        <Text size="2">No dependencies found</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box>
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeaderCell>Name</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Version</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Description</Table.ColumnHeaderCell>
+            <Table.ColumnHeaderCell>Features</Table.ColumnHeaderCell>
+          </Table.Row>
+        </Table.Header>
+
+        <Table.Body>
+          {dependencies.map((dep) => (
+            <Table.Row key={dep.name}>
+              <Table.Cell>
+                <Text size="2" weight="medium">
+                  {dep.name}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="2">{dep.version}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text size="2">{dep.description}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Box style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+                  {dep.features?.map((feature) => (
+                    <Badge key={feature} size="1" variant="soft">
+                      {feature}
+                    </Badge>
+                  ))}
+                  {dep.isOptional && (
+                    <Badge size="1" variant="soft" color="orange">
+                      Optional
+                    </Badge>
+                  )}
+                </Box>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+};

--- a/src/pages/PublicPackageDetails.tsx
+++ b/src/pages/PublicPackageDetails.tsx
@@ -2,6 +2,7 @@ import { Box, Tabs, Text } from "@radix-ui/themes";
 import React from "react";
 import { NavBar } from "../components/NavBar";
 import { Link, useParams } from "react-router-dom";
+import { DependenciesList } from "../components/DependenciesList";
 
 export const PublicPackageDetails: React.FC = () => {
   // Get the Package ID and Version from the URL path /package/:id/:version
@@ -57,9 +58,7 @@ export const PublicPackageDetails: React.FC = () => {
                   <Text size="2">List of versions for this package</Text>
                 </Tabs.Content>
                 <Tabs.Content value="dependencies">
-                  <Text size="2">
-                    Dependencies for this package will be listed here
-                  </Text>
+                  <DependenciesList packageId={packageId || ''} version={packageVersion || ''} />
                 </Tabs.Content>
               </Box>
             </Tabs.Root>


### PR DESCRIPTION


## Changes Made
- Implemented Dependencies tab in package details page
- Added new DependenciesList component with responsive table view
- Created API structure for future integration
- Added TypeScript types for dependency data

## Features
- Table view showing package dependencies with name, version, description
- Feature badges with visual indicators for optional dependencies
- Loading, error, and empty state handling
- Responsive layout using Radix UI components
- Type-safe implementation with TypeScript

## Technical Details
- Created `api/types.ts` for dependency interfaces
- Added `api/packageApi.ts` with dummy data (ready for real API integration)
- New `DependenciesList.tsx` component with error handling
- Updated `PublicPackageDetails.tsx` to integrate dependencies view

## Screenshots
[You can add screenshots of the new dependencies tab here]

## Testing
- Verify dependencies load correctly
- Check loading states
- Validate error handling
- Test empty state
- Confirm feature badges display correctly

## Notes
- Currently using dummy data in packageApi.ts
- Ready for real API integration when available